### PR TITLE
fix(release): add repository field for npm provenance, fix bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
     "description": "CLI tool to add Cashfree MCP configurations to AI coding assistants",
     "type": "module",
     "main": "dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/cashfree/agent-skills.git"
+    },
     "bin": {
-        "cashfree": "./dist/index.js"
+        "cashfree": "dist/index.js"
     },
     "scripts": {
         "build": "tsc && npm run copy-templates",


### PR DESCRIPTION
npm Trusted Publishing rejects the publish (E422) when repository.url doesn't match the GitHub repo, and npm 11 strips the bin entry when the path has a ./ prefix.