### PR TITLE
fix: shorten SKILL.md name/description to pass loader limits

### DIFF
--- a/src/templates/changelog/references/pg-mobile-sdks.md
+++ b/src/templates/changelog/references/pg-mobile-sdks.md
@@ -1,5 +1,5 @@
 ---
-name: Changelog — PG Mobile SDKs (Android, iOS, Flutter, React Native, Cordova, Capacitor)
+name: Changelog — PG Mobile SDKs (Android, iOS, Flutter, RN, Cordova)
 description: >
   Source-verified changelog for Cashfree's PG mobile SDKs, drawn primarily from the
   cashfree/docs per-platform changelog .mdx files (Cashfree's own dated notes) and

--- a/src/templates/changelog/references/pg-web-sdk.md
+++ b/src/templates/changelog/references/pg-web-sdk.md
@@ -1,5 +1,5 @@
 ---
-name: Changelog — PG Web / JS SDKs (cashfree.js v3, pg-react, pg-svelte)
+name: Changelog — PG Web / JS SDKs (cashfree.js v3, react, svelte)
 description: >
   Source-verified changelog for Cashfree's PG browser/JS SDKs — cashfree.js (the
   /js/v3/ browser SDK + npm @cashfreepayments/cashfree-js), pg-react, pg-svelte.

--- a/src/templates/common-mistakes.md
+++ b/src/templates/common-mistakes.md
@@ -1,5 +1,5 @@
 ---
-name: Cashfree Payment Gateway - Common Integration Mistakes & Pitfalls
+name: Cashfree Payment Gateway - Common Integration Mistakes
 description: >
   Use when a developer is debugging a failed integration, encountering errors, or asking
   why something isn't working.

--- a/src/templates/migrate-from-juspay.md
+++ b/src/templates/migrate-from-juspay.md
@@ -1,5 +1,5 @@
 ---
-name: Migrate Payment Orchestrator / Gateway - Juspay to Cashfree Payments
+name: Migrate Payment Gateway - Juspay to Cashfree Payments
 description: >
   Use when migrating an existing Juspay integration to Cashfree Payments.
   Triggers: migrate from Juspay to Cashfree, replace Juspay with Cashfree, switch from Juspay

--- a/src/templates/migrate-from-payu.md
+++ b/src/templates/migrate-from-payu.md
@@ -1,18 +1,17 @@
 ---
 name: Migrate Payment Gateway - PayU to Cashfree Payments
 description: >
-  Use when migrating an existing PayU (PayU India / PayUBiz / PayUMoney) Payment Gateway integration to
+  Use when migrating an existing PayU (PayUBiz / PayUMoney) Payment Gateway integration to
   Cashfree Payments. Triggers: migrate from PayU to Cashfree, replace PayU with Cashfree, switch payment
-  gateway from PayU, port PayU integration, PayU to Cashfree, swap PayU, PayU vs Cashfree, replace
-  secure.payu.in/_payment, replace test.payu.in, rewrite PayU _payment form post, move off PayU, deprecate
-  PayU, replace PayU key and salt with Cashfree headers, replace SHA-512 PayU hash with Cashfree signature,
-  convert txnid to order_id, convert mihpayid to cf_payment_id, replace PayU reverse hash verification with
-  Cashfree backend re-fetch, replace surl furl with return_url, translate PayU verify_payment to Cashfree
-  fetch order, migrate PayU cancel_refund_transaction to Cashfree refund, translate PayU webhook hash to
-  x-webhook-signature, replace PayU Bolt checkout with Cashfree.js, migrate PayU CheckoutPro mobile SDK to
-  Cashfree mobile SDK, migrate PayU SI Standing Instruction to Cashfree Subscriptions, PayU success failure
-  pending status to Cashfree PAID. Pair this with the Cashfree backend-sdks, apis, webhooks, web-sdk,
-  mobile-sdks, subscriptions, and go-live skills once the mapping is clear.
+  gateway from PayU, port PayU integration, replace secure.payu.in/_payment,
+  rewrite PayU _payment form post, move off PayU, replace PayU key and salt with Cashfree headers,
+  replace SHA-512 PayU hash with Cashfree signature, convert txnid to order_id, convert mihpayid to
+  cf_payment_id, replace PayU reverse hash verification with Cashfree backend re-fetch, replace surl
+  furl with return_url, translate PayU verify_payment to Cashfree fetch order, migrate PayU
+  cancel_refund_transaction to Cashfree refund, translate PayU webhook hash to x-webhook-signature,
+  replace PayU Bolt checkout with Cashfree.js, migrate PayU CheckoutPro SDK to Cashfree mobile
+  SDK, migrate PayU SI to Subscriptions. Pair this with the Cashfree backend-sdks, apis,
+  webhooks, web-sdk, mobile-sdks, and subscriptions skills once the mapping is clear.
 ---
 
 # Migrating From PayU to Cashfree Payments

--- a/src/templates/migrate-from-razorpay.md
+++ b/src/templates/migrate-from-razorpay.md
@@ -3,9 +3,9 @@ name: Migrate Payment Gateway - Razorpay to Cashfree Payments
 description: >
   Use when migrating an existing Razorpay Payment Gateway integration to Cashfree Payments.
   Triggers: migrate from Razorpay to Cashfree, replace Razorpay with Cashfree, switch payment
-  gateway from Razorpay, port Razorpay integration, Razorpay to Cashfree, swap Razorpay,
-  Razorpay vs Cashfree, replace razorpay-node, replace razorpay pip, replace checkout.razorpay.com,
-  rewrite Razorpay checkout, move off Razorpay, deprecate Razorpay, convert razorpay_payment_id
+  gateway from Razorpay, port Razorpay integration, Razorpay to Cashfree,
+  replace razorpay-node, replace razorpay pip, replace checkout.razorpay.com,
+  rewrite Razorpay checkout, move off Razorpay, convert razorpay_payment_id
   to cf_payment_id, translate Razorpay webhook to Cashfree webhook, change X-Razorpay-Signature
   to x-webhook-signature, port razorpay.orders.create, port Razorpay handler to Cashfree,
   reimplement Razorpay signature verification with Cashfree, migrate Razorpay refund to Cashfree,

--- a/src/templates/pg/easy-split.md
+++ b/src/templates/pg/easy-split.md
@@ -1,5 +1,5 @@
 ---
-name: Cashfree Payment Gateway - Easy Split (Marketplace Split Payments)
+name: Cashfree Payment Gateway - Easy Split (Marketplace)
 description: >
   Use when building a marketplace / platform flow where a single customer payment must be
   split across multiple vendors (sellers, partners, drivers, agents) with Cashfree handling

--- a/src/templates/subscriptions.md
+++ b/src/templates/subscriptions.md
@@ -6,11 +6,11 @@ description: >
   standing instructions, SI on cards, physical NACH, subscription plan, create subscription, charge subscription,
   subscription webhook, subscription checkout, subscription_session_id, periodic subscription, on-demand subscription,
   mandate authorization, subscription lifecycle, subscription status, BANK_APPROVAL_PENDING, subscription refund,
-  subscription SDK, Android subscription SDK, iOS subscription SDK, Flutter subscription SDK, React Native subscription,
-  Cordova subscription, subscription payment failed, subscription retry, cancel subscription, pause subscription,
-  reactivate subscription, import mandates, batch subscriptions, subscription card expiry, subscription hosted checkout,
-  PGCreatePlan, PGCreateSubscription, subscription_first_charge_time, subscription_expiry_time, plan_type PERIODIC,
-  plan_type ON_DEMAND, subscription payment modes, subscription error codes, subscription rate limits.
+  subscription SDK, Android/iOS/Flutter/React Native subscription SDK, subscription payment failed,
+  subscription retry, cancel subscription, pause subscription, reactivate subscription,
+  subscription card expiry, subscription hosted checkout, PGCreatePlan, PGCreateSubscription,
+  subscription_first_charge_time, subscription_expiry_time, plan_type PERIODIC, plan_type ON_DEMAND,
+  subscription payment modes, subscription error codes, subscription rate limits.
 ---
 
 # Cashfree Subscriptions — Recurring Payments & Mandates


### PR DESCRIPTION
Several skill files exceeded Codex's frontmatter limits (name ≤ 64, description ≤ 1024 chars) and were silently skipped on load. Shorten the affected names and trim redundant trigger keywords from descriptions, and add a test enforcing both limits across all templates.